### PR TITLE
adding database tests + helpers directory for database test

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -53,7 +53,7 @@ const makeid = require('./helpers/makeid.js');
 
 // initialising test database with test db url
 let db = new Pool({
-    connectionString: process.env.TEST_DB_URL
+    connectionString: "postgres://ixcaudug:VDR2bn6KlbHgKwI6TmRAvAMmZESR5VIJ@trumpet.db.elephantsql.com/ixcaudug"
 });
 
 // seeding database with the testing data

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,5 +1,6 @@
+// create test database (doesn't look like it's being used but it is)
+const db = require('./config/postgres-test-db.js');
 const app = require('./app.js');
-const fs = require('fs')
 const supertest = require('supertest-session');
 
 const request = supertest(app);
@@ -20,7 +21,6 @@ describe('Event Routes - /events - not logged in', () => {
         expect(response.statusCode).toBe(401);
         expect(JSON.stringify(response.body)).toBe(message);
     });
-
 });
 
 describe('Auth Routes - /auth', () => {
@@ -46,24 +46,7 @@ describe('Auth Routes - /auth', () => {
     });
 });
 
-
-// creating test database
-const { Pool } = require('pg');
 const makeid = require('./helpers/makeid.js');
-
-// initialising test database with test db url
-let db = new Pool({
-    connectionString: "postgres://ixcaudug:VDR2bn6KlbHgKwI6TmRAvAMmZESR5VIJ@trumpet.db.elephantsql.com/ixcaudug"
-});
-
-// seeding database with the testing data
-const sql = fs.readFileSync(process.cwd() + '/src/config/setup.sql').toString();
-db.query(sql)
-    .then(data => {
-        db.end();
-        console.log("Set-up complete.");
-    })
-    .catch(error => console.log(error));
 
 describe('Database Tests - /event', () => {
     it('POST /auth/login - Should log me in as admin.', async () => {

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,4 +1,5 @@
 const app = require('./app.js');
+const fs = require('fs')
 const supertest = require('supertest-session');
 
 const request = supertest(app);
@@ -42,5 +43,65 @@ describe('Auth Routes - /auth', () => {
 
         expect(response.statusCode).toBe(200);
         expect(response.body.authenticated).toBe(false);
+    });
+});
+
+
+// creating test database
+const { Pool } = require('pg');
+const makeid = require('./helpers/makeid.js');
+
+// initialising test database with test db url
+let db = new Pool({
+    connectionString: process.env.TEST_DB_URL
+});
+
+// seeding database with the testing data
+const sql = fs.readFileSync(process.cwd() + '/src/config/setup.sql').toString();
+db.query(sql)
+    .then(data => {
+        db.end();
+        console.log("Set-up complete.");
+    })
+    .catch(error => console.log(error));
+
+describe('Database Tests - /event', () => {
+    it('POST /auth/login - Should log me in as admin.', async () => {
+        const response = await request.post('/auth/login').send({ username: "admin", password: "admin" });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.authenticated).toBe(true);
+    });
+
+    it('POST /event - Should create a new event as an admin.', async () => {
+        let payload = {
+            upvotes: 99, title: "This is a test event.", description: "I repeat, this is a test event. This description is just dummy text in order to make it look like there is some kind of even being described. If you've read this far I don't know wheather to commend or question you...", location: "London"
+        };
+        const response = await request.post('/events').send(payload);
+
+
+        expect(response.statusCode).toBe(201);
+    });
+
+    it('GET /auth/logout - Should log user out.', async () => {
+        const response = await request.get('/auth/logout');
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.authenticated).toBe(false);
+    });
+
+    it('POST X2 /auth/register - Should register, and login user.', async () => {
+        // create random username and register account
+        let hash = makeid(4)
+        let username = "test_user" + hash;
+        const response = await request.post('/auth/register').send({ username, email: "whocares@gmail.com", password: "test_password" });
+
+        expect(response.statusCode).toBe(201);
+
+        // login with the created credentials
+        let response2 = await request.post('/auth/login').send({ username, password: "test_password" });
+
+        expect(response2.statusCode).toBe(200);
+        expect(response2.body.authenticated).toBe(true);
     });
 });

--- a/src/config/postgres-test-db.js
+++ b/src/config/postgres-test-db.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+
+// creating test database
+const { Pool } = require('pg');
+// initialising test database with test db url
+let testdb = new Pool({
+    connectionString: "postgres://ixcaudug:VDR2bn6KlbHgKwI6TmRAvAMmZESR5VIJ@trumpet.db.elephantsql.com/ixcaudug"
+});
+
+// seeding database with the testing data
+const sql = fs.readFileSync(process.cwd() + '/src/config/setup.sql').toString();
+testdb.query(sql)
+    .then(data => {
+        testdb.end();
+        console.log("Set-up complete.");
+    })
+    .catch(error => console.log(error));
+
+module.exports = testdb;

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -41,7 +41,7 @@ const deleteEvent = async (req, res) => {
         return res.status(404).json({ error: error.message })
     }
 }
-// POST events/ - get an account's events
+// POST events/ - create an event
 const createEvent = async (req, res) => {
     if (!req.session.user.isAdmin) {
         return res.status(401).json({ error: 'sorry buddy, admins only.' })

--- a/src/helpers/makeid.js
+++ b/src/helpers/makeid.js
@@ -1,0 +1,13 @@
+function makeid(length) {
+    let result = '';
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const charactersLength = characters.length;
+    let counter = 0;
+    while (counter < length) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+        counter += 1;
+    }
+    return result;
+}
+
+module.exports = makeid;


### PR DESCRIPTION
### Read me!!!!!!! c:

With the addition of the database tests we have in total 9 tests each testing different functionality of the code.
![image](https://user-images.githubusercontent.com/75338985/228367606-c6e033e0-4131-4516-8840-8388b3dd27af.png)

At the moment the tests are focused mainly on the authentication and registration of users, but I see room for improvement on the testing of the /events creation and deletion here.


Either way though, this is the threshold for testing done.
![image](https://user-images.githubusercontent.com/75338985/228369121-7c9e2f0e-f6c6-4979-8984-5461a45bafd5.png)
